### PR TITLE
don't use contexts for deadlines

### DIFF
--- a/deadline.go
+++ b/deadline.go
@@ -1,0 +1,80 @@
+// Copied from the go standard library.
+//
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE-BSD file.
+
+package multiplex
+
+import (
+	"sync"
+	"time"
+)
+
+// pipeDeadline is an abstraction for handling timeouts.
+type pipeDeadline struct {
+	mu     sync.Mutex // Guards timer and cancel
+	timer  *time.Timer
+	cancel chan struct{} // Must be non-nil
+}
+
+func makePipeDeadline() pipeDeadline {
+	return pipeDeadline{cancel: make(chan struct{})}
+}
+
+// set sets the point in time when the deadline will time out.
+// A timeout event is signaled by closing the channel returned by waiter.
+// Once a timeout has occurred, the deadline can be refreshed by specifying a
+// t value in the future.
+//
+// A zero value for t prevents timeout.
+func (d *pipeDeadline) set(t time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.timer != nil && !d.timer.Stop() {
+		<-d.cancel // Wait for the timer callback to finish and close cancel
+	}
+	d.timer = nil
+
+	// Time is zero, then there is no deadline.
+	closed := isClosedChan(d.cancel)
+	if t.IsZero() {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		return
+	}
+
+	// Time in the future, setup a timer to cancel in the future.
+	if dur := time.Until(t); dur > 0 {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		d.timer = time.AfterFunc(dur, func() {
+			close(d.cancel)
+		})
+		return
+	}
+
+	// Time in the past, so close immediately.
+	if !closed {
+		close(d.cancel)
+	}
+}
+
+// wait returns a channel that is closed when the deadline is exceeded.
+func (d *pipeDeadline) wait() chan struct{} {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.cancel
+}
+
+func isClosedChan(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}

--- a/multiplex.go
+++ b/multiplex.go
@@ -34,7 +34,7 @@ var ErrTwoInitiators = errors.New("two initiators")
 // In this case, we close the connection to be safe.
 var ErrInvalidState = errors.New("received an unexpected message from the peer")
 
-var errTimeout = errors.New("timeout")
+var errTimeout = timeout{}
 var errStreamClosed = errors.New("stream closed")
 
 var (
@@ -43,6 +43,20 @@ var (
 
 	WriteCoalesceDelay = 100 * time.Microsecond
 )
+
+type timeout struct{}
+
+func (_ timeout) Error() string {
+	return "timeout"
+}
+
+func (_ timeout) Temporary() bool {
+	return true
+}
+
+func (_ timeout) Timeout() bool {
+	return true
+}
 
 // +1 for initiator
 const (

--- a/multiplex.go
+++ b/multiplex.go
@@ -47,7 +47,7 @@ var (
 type timeout struct{}
 
 func (_ timeout) Error() string {
-	return "timeout"
+	return "i/o deadline exceeded"
 }
 
 func (_ timeout) Temporary() bool {

--- a/multiplex.go
+++ b/multiplex.go
@@ -35,6 +35,7 @@ var ErrTwoInitiators = errors.New("two initiators")
 var ErrInvalidState = errors.New("received an unexpected message from the peer")
 
 var errTimeout = errors.New("timeout")
+var errStreamClosed = errors.New("stream closed")
 
 var (
 	NewStreamTimeout   = time.Minute

--- a/multiplex.go
+++ b/multiplex.go
@@ -93,11 +93,13 @@ func NewMultiplex(con net.Conn, initiator bool) *Multiplex {
 
 func (mp *Multiplex) newStream(id streamID, name string) (s *Stream) {
 	s = &Stream{
-		id:     id,
-		name:   name,
-		dataIn: make(chan []byte, 8),
-		reset:  make(chan struct{}),
-		mp:     mp,
+		id:        id,
+		name:      name,
+		dataIn:    make(chan []byte, 8),
+		reset:     make(chan struct{}),
+		rDeadline: makePipeDeadline(),
+		wDeadline: makePipeDeadline(),
+		mp:        mp,
 	}
 
 	s.closedLocal, s.doCloseLocal = context.WithCancel(context.Background())
@@ -148,7 +150,7 @@ func (mp *Multiplex) IsClosed() bool {
 	}
 }
 
-func (mp *Multiplex) sendMsg(ctx context.Context, header uint64, data []byte) error {
+func (mp *Multiplex) sendMsg(done <-chan struct{}, header uint64, data []byte) error {
 	buf := pool.Get(len(data) + 20)
 
 	n := 0
@@ -161,8 +163,8 @@ func (mp *Multiplex) sendMsg(ctx context.Context, header uint64, data []byte) er
 		return nil
 	case <-mp.shutdown:
 		return ErrShutdown
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-done:
+		return errors.New("invalid context")
 	}
 }
 
@@ -295,7 +297,7 @@ func (mp *Multiplex) NewNamedStream(name string) (*Stream, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), NewStreamTimeout)
 	defer cancel()
 
-	err := mp.sendMsg(ctx, header, []byte(name))
+	err := mp.sendMsg(ctx.Done(), header, []byte(name))
 	if err != nil {
 		return nil, err
 	}
@@ -407,6 +409,7 @@ func (mp *Multiplex) handleIncoming() {
 			if !isClosed {
 				msch.doCloseLocal()
 			}
+
 			msch.clLock.Unlock()
 
 			msch.cancelDeadlines()
@@ -507,7 +510,7 @@ func (mp *Multiplex) sendResetMsg(header uint64, hard bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), ResetStreamTimeout)
 	defer cancel()
 
-	err := mp.sendMsg(ctx, header, nil)
+	err := mp.sendMsg(ctx.Done(), header, nil)
 	if err != nil && !mp.isShutdown() {
 		if hard {
 			log.Warningf("error sending reset message: %s; killing connection", err.Error())

--- a/multiplex.go
+++ b/multiplex.go
@@ -407,8 +407,9 @@ func (mp *Multiplex) handleIncoming() {
 			if !isClosed {
 				msch.doCloseLocal()
 			}
-
 			msch.clLock.Unlock()
+
+			msch.cancelDeadlines()
 
 			mp.chLock.Lock()
 			delete(mp.channels, ch)
@@ -435,6 +436,7 @@ func (mp *Multiplex) handleIncoming() {
 			msch.clLock.Unlock()
 
 			if cleanup {
+				msch.cancelDeadlines()
 				mp.chLock.Lock()
 				delete(mp.channels, ch)
 				mp.chLock.Unlock()

--- a/multiplex.go
+++ b/multiplex.go
@@ -34,6 +34,8 @@ var ErrTwoInitiators = errors.New("two initiators")
 // In this case, we close the connection to be safe.
 var ErrInvalidState = errors.New("received an unexpected message from the peer")
 
+var errTimeout = errors.New("timeout")
+
 var (
 	NewStreamTimeout   = time.Minute
 	ResetStreamTimeout = 2 * time.Minute
@@ -164,7 +166,7 @@ func (mp *Multiplex) sendMsg(done <-chan struct{}, header uint64, data []byte) e
 	case <-mp.shutdown:
 		return ErrShutdown
 	case <-done:
-		return errors.New("invalid context")
+		return errTimeout
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -251,7 +251,7 @@ func (s *Stream) SetDeadline(t time.Time) error {
 	s.clLock.Lock()
 	defer s.clLock.Unlock()
 
-	if s.closedRemote && s.isClosed() {
+	if s.closedRemote || s.isClosed() {
 		return errStreamClosed
 	}
 

--- a/stream.go
+++ b/stream.go
@@ -248,17 +248,38 @@ func (s *Stream) cancelDeadlines() {
 }
 
 func (s *Stream) SetDeadline(t time.Time) error {
+	s.clLock.Lock()
+	defer s.clLock.Unlock()
+
+	if s.closedRemote && s.isClosed() {
+		return errStreamClosed
+	}
+
 	s.rDeadline.set(t)
 	s.wDeadline.set(t)
 	return nil
 }
 
 func (s *Stream) SetReadDeadline(t time.Time) error {
+	s.clLock.Lock()
+	defer s.clLock.Unlock()
+
+	if s.closedRemote {
+		return errStreamClosed
+	}
+
 	s.rDeadline.set(t)
 	return nil
 }
 
 func (s *Stream) SetWriteDeadline(t time.Time) error {
+	s.clLock.Lock()
+	defer s.clLock.Unlock()
+
+	if s.isClosed() {
+		return errStreamClosed
+	}
+
 	s.wDeadline.set(t)
 	return nil
 }

--- a/stream.go
+++ b/stream.go
@@ -82,7 +82,7 @@ func (s *Stream) waitForData() error {
 		s.exbuf = read
 		return nil
 	case <-s.rDeadline.wait():
-		return context.DeadlineExceeded
+		return errTimeout
 	}
 }
 


### PR DESCRIPTION
We are creating tons of contexts when there are deadlines... one for every read/write.