### PR TITLE
Re-enable write coalescing

### DIFF
--- a/multiplex.go
+++ b/multiplex.go
@@ -192,11 +192,7 @@ func (mp *Multiplex) handleOutgoing() {
 			return
 
 		case data := <-mp.writeCh:
-			// FIXME: https://github.com/libp2p/go-libp2p/issues/644
-			// write coalescing disabled until this can be fixed.
-			//err := mp.writeMsg(data)
-			err := mp.doWriteMsg(data)
-			pool.Put(data)
+			err := mp.writeMsg(data)
 			if err != nil {
 				// the connection is closed by this time
 				log.Warningf("error writing data: %s", err.Error())


### PR DESCRIPTION
Note: DO NOT MERGE YET. We will merge it once ipfs 0.4.21 has shipped

This re-enables write-coalescing, because we really want it.
Closes #62 
See https://github.com/libp2p/go-libp2p/issues/644