### PR TITLE
Remove dependency on go-libp2p-core and introduce new errors.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/libp2p/go-mplex
 
+go 1.13
+
 require (
 	github.com/ipfs/go-log v0.0.1
 	github.com/libp2p/go-buffer-pool v0.0.2
-	github.com/libp2p/go-libp2p-core v0.3.0
 )

--- a/multiplex_test.go
+++ b/multiplex_test.go
@@ -8,8 +8,6 @@ import (
 	"net"
 	"testing"
 	"time"
-
-	tmux "github.com/libp2p/go-libp2p-core/mux"
 )
 
 func init() {
@@ -391,7 +389,7 @@ func TestResetAfterEOF(t *testing.T) {
 	sb.Reset()
 
 	n, err = sa.Read([]byte{0})
-	if n != 0 || err != tmux.ErrReset {
+	if n != 0 || err != ErrStreamReset {
 		t.Fatal(err)
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -7,9 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/mux"
-
 	pool "github.com/libp2p/go-buffer-pool"
+)
+
+var (
+	ErrStreamReset  = errors.New("stream reset")
+	ErrStreamClosed = errors.New("closed stream")
 )
 
 // streamID is a convenience type for operating on stream IDs
@@ -74,7 +77,7 @@ func (s *Stream) waitForData() error {
 	case <-s.reset:
 		// This is the only place where it's safe to return these.
 		s.returnBuffers()
-		return mux.ErrReset
+		return ErrStreamReset
 	case read, ok := <-s.dataIn:
 		if !ok {
 			return io.EOF
@@ -112,7 +115,7 @@ func (s *Stream) returnBuffers() {
 func (s *Stream) Read(b []byte) (int, error) {
 	select {
 	case <-s.reset:
-		return 0, mux.ErrReset
+		return 0, ErrStreamReset
 	default:
 	}
 	if s.extra == nil {
@@ -160,14 +163,14 @@ func (s *Stream) Write(b []byte) (int, error) {
 
 func (s *Stream) write(b []byte) (int, error) {
 	if s.isClosed() {
-		return 0, errors.New("cannot write to closed stream")
+		return 0, ErrStreamClosed
 	}
 
 	err := s.mp.sendMsg(s.wDeadline.wait(), s.id.header(messageTag), b)
 
 	if err != nil {
 		if err == context.Canceled {
-			err = errors.New("cannot write to closed stream")
+			err = ErrStreamClosed
 		}
 		return 0, err
 	}


### PR DESCRIPTION
See libp2p/go-libp2p#814 and libp2p/go-yamux#6 for details.

This should be done before touching `go-libp2p-yamux` for it to be able to replace the new `ErrStreamReset` to `mux.ErrReset`.