### PR TITLE
adjust dataIn buffer size for the actual allotment of buffers

### DIFF
--- a/multiplex.go
+++ b/multiplex.go
@@ -93,6 +93,7 @@ type Multiplex struct {
 	chLock   sync.Mutex
 
 	bufIn, bufOut  chan struct{}
+	bufMax         int
 	reservedMemory int
 }
 
@@ -137,6 +138,7 @@ func NewMultiplex(con net.Conn, initiator bool, memoryManager MemoryManager) (*M
 		return nil, err
 	}
 
+	mp.bufMax = bufs
 	mp.bufIn = make(chan struct{}, bufs)
 	mp.bufOut = make(chan struct{}, bufs)
 
@@ -150,7 +152,7 @@ func (mp *Multiplex) newStream(id streamID, name string) (s *Stream) {
 	s = &Stream{
 		id:          id,
 		name:        name,
-		dataIn:      make(chan []byte, 8),
+		dataIn:      make(chan []byte, mp.bufMax),
 		rDeadline:   makePipeDeadline(),
 		wDeadline:   makePipeDeadline(),
 		mp:          mp,

--- a/multiplex.go
+++ b/multiplex.go
@@ -139,7 +139,7 @@ func NewMultiplex(con net.Conn, initiator bool, memoryManager MemoryManager) (*M
 		return nil, err
 	}
 
-	mp.bufMax = bufs
+	mp.bufMax = bufs - 1
 	mp.bufIn = make(chan struct{}, bufs)
 	mp.bufOut = make(chan struct{}, bufs)
 	mp.timerIn = time.NewTimer(ReadDeadlockTimeout)


### PR DESCRIPTION
so that if we have a slow reader blocking it will eventually time out.
Also adds a timeout for acquiring a read buffer so that we don't block indefinitely if we have a bunch of stuck application streams not returning buffers.

follow up from #99.