### PR TITLE
Fix the race condition in stream reading loop

### DIFF
--- a/multiplex.go
+++ b/multiplex.go
@@ -171,7 +171,9 @@ func (mp *Multiplex) newStream(id streamID, name string) (s *Stream) {
 		mp:          mp,
 		writeCancel: make(chan struct{}),
 		readCancel:  make(chan struct{}),
+		extraBufs:   make(chan extraBufs, 1),
 	}
+	s.extraBufs <- extraBufs{}
 	return
 }
 


### PR DESCRIPTION
Problem: under substantial load with many concurrent threads
communicating on different streams, there might be a condition in which
Read() would finish due to a stream reset without properly releasing the
input buffers. When this condition is repeated on the same connection
(for different streams), some stream may be unable to allocate an input
buffer and communication would stuck on one side of the connection.

Similarly, case of deadline could leave some resources in an unreleased
state.

Solution: make stream read cancelation responsible for releasing
resources. To make this work management of extra buffers (which contains
data already fetched from dataIn channel) is now made through a chan and
it's ensured that in any condition resource will be released.